### PR TITLE
Improve information about graphics card in xfce4-about dialog

### DIFF
--- a/x11/libxfce4menu/Makefile
+++ b/x11/libxfce4menu/Makefile
@@ -14,7 +14,9 @@ COMMENT=	Widgets library for the Xfce desktop environment
 LICENSE=	GPLv2
 
 LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
-		libfreetype.so:print/freetype2
+		libfreetype.so:print/freetype2 \
+		libepoxy.so:graphics/libepoxy \
+		libgtop-2.0.so:devel/libgtop
 
 USES=		compiler:c11 gettext-tools gmake gnome libtool pathfix \
 		pkgconfig tar:bzip2 xfce xorg
@@ -25,7 +27,9 @@ USE_XORG=	ice sm x11
 
 GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-CONFIGURE_ARGS=	--with-vendor-info=${OPSYS} --without-html-dir
+CONFIGURE_ARGS=	--with-vendor-info=${OPSYS} --without-html-dir \
+		--enable-glibtop --enable-epoxy \
+		--disable-gudev
 INSTALL_TARGET=	install-strip
 
 PORTSCOUT=	limitw:1,even


### PR DESCRIPTION
Adjust dependencies related to graphics card in xfce4-about dialog.

In xfce4-about/system-info.c the file /etc/os-release is read. I don't know if this file is available for 11.4-RELEASE, os-release(5) says,  it appeared in FreeBSD 13.0
I use 12.2-RELEASE and this file is available, otherwise we get this information with sysutils/etc_os-release port.